### PR TITLE
SWATCH-3103: Create wiremock container for CI based on UBI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1739751568 AS build
+
+USER 0
+
+ENV WIREMOCK_VERSION 3.12.0
+
+# grab wiremock standalone jar
+RUN mkdir -p /var/wiremock/lib/ \
+  && curl https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/$WIREMOCK_VERSION/wiremock-standalone-$WIREMOCK_VERSION.jar \
+    -o /var/wiremock/lib/wiremock-standalone.jar
+
+# Runtime
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.21-1.1739376163
+COPY --from=build /var/wiremock/lib/wiremock-standalone.jar /var/wiremock/lib/wiremock-standalone.jar
+
+LABEL maintainer="Red Hat, Inc."
+
+LABEL version="ubi9"
+#label for EULA
+LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+WORKDIR /home/wiremock
+USER 0
+
+# Init WireMock files structure
+RUN mkdir -p /home/wiremock/mappings && \
+	mkdir -p /home/wiremock/__files && \
+	mkdir -p /var/wiremock/extensions
+
+COPY docker-entrypoint.sh /
+
+EXPOSE 8000
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -exv
+
+IMAGE="quay.io/cloudservices/wiremock"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+docker build -t "${IMAGE}:${IMAGE_TAG}" .
+
+if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+
+    # build also "latest" tag
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+fi

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -9,7 +9,7 @@ parameters:
   - name: WIREMOCK_IMAGE
     value: quay.io/cloudservices/wiremock
   - name: WIREMOCK_IMAGE_TAG
-    value: 3x-alpine
+    value: latest
   - name: MEMORY_REQUEST
     value: 256Mi
   - name: MEMORY_LIMIT
@@ -59,7 +59,7 @@ objects:
                     key: keystore_password
               - name: WIREMOCK_OPTIONS
                 # Wiremock uses the truststore instead of keystore to read client certs: https://wiremock.org/docs/proxying/#proxying-to-a-target-server-that-requires-client-certificate-authentication
-                value: --port=8000 --https-truststore=/pinhead/keystore.jks --truststore-type=JKS --truststore-password=$(KEYSTORE_PASSWORD)
+                value: --https-truststore=/pinhead/keystore.jks --truststore-type=JKS --truststore-password=$(KEYSTORE_PASSWORD)
             livenessProbe:
               failureThreshold: 3
               httpGet:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Set `java` command if needed
+if [ "$1" = "" -o "${1:0:1}" = "-" ]; then
+  set -- java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* wiremock.Run "$@"
+fi
+
+exec "$@" --port=8000 $WIREMOCK_OPTIONS

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -exv
+
+IMAGE="quay.io/cloudservices/wiremock"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+docker build -t "${IMAGE}:${IMAGE_TAG}" .


### PR DESCRIPTION
Changes:

(1) add a custom Dockerfile based on what is being done on upstream for wiremock, but using UBI as base image.
(2) add pr_check.sh file to verify the build
(3) add build_deploy.sh file to push the latest and git hash base images into quay

Test Steps:
1.- Run `sh pr_check.sh`

Output:
```
...
[2/2] STEP 8/11: RUN mkdir -p /home/wiremock/mappings && 	mkdir -p /home/wiremock/__files && 	mkdir -p /var/wiremock/extensions
--> Using cache 428aa7ab1509607061d12b1fd054bb0e351d8a215caf0a498e31e936a5f46f78
--> 428aa7ab1509
[2/2] STEP 9/11: COPY docker-entrypoint.sh /
--> Using cache 1521561d3dbb9c1e982a5f524706e352cf8730ebe112fcebe99aba327245725d
--> 1521561d3dbb
[2/2] STEP 10/11: EXPOSE 8000
--> Using cache 515d75c3ef688c154b203bef986919ec7414eee5233071eac1967e81f257b76a
--> 515d75c3ef68
[2/2] STEP 11/11: ENTRYPOINT ["/docker-entrypoint.sh"]
--> Using cache 02657fe28d91cb0c185622ae9036597d018002632dba08d51893a25678e77c54
[2/2] COMMIT quay.io/cloudservices/wiremock:490b0b8
--> 02657fe28d91
Successfully tagged quay.io/cloudservices/wiremock:490b0b8
02657fe28d91cb0c185622ae9036597d018002632dba08d51893a25678e77c54
```

2.- Run `podman run quay.io/cloudservices/wiremock:490b0b8` 

Make sure 490b0b8 is the generated image from the previous step.
Output:
```
podman run quay.io/cloudservices/wiremock:490b0b8

██     ██ ██ ██████  ███████ ███    ███  ██████   ██████ ██   ██ 
██     ██ ██ ██   ██ ██      ████  ████ ██    ██ ██      ██  ██  
██  █  ██ ██ ██████  █████   ██ ████ ██ ██    ██ ██      █████   
██ ███ ██ ██ ██   ██ ██      ██  ██  ██ ██    ██ ██      ██  ██  
 ███ ███  ██ ██   ██ ███████ ██      ██  ██████   ██████ ██   ██ 

----------------------------------------------------------------
|               Cloud: https://wiremock.io/cloud               |
|                                                              |
|               Slack: https://slack.wiremock.org              |
----------------------------------------------------------------

version:                      3.12.0
port:                         8000
enable-browser-proxying:      false
disable-banner:               false
no-request-journal:           false
verbose:                      false

extensions:                   response-template,webhook
```