### PR TITLE
Revert "bump memory limit and request"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -11,9 +11,9 @@ parameters:
   - name: WIREMOCK_IMAGE_TAG
     value: latest
   - name: MEMORY_REQUEST
-    value: 512Mi
+    value: 256Mi
   - name: MEMORY_LIMIT
-    value: 1Gi
+    value: 512Mi
   - name: CPU_REQUEST
     value: 150m
   - name: CPU_LIMIT


### PR DESCRIPTION
Reverts RedHatInsights/wiremock-consoledot#24

To be merged after verifying https://github.com/RedHatInsights/wiremock-consoledot/pull/25 